### PR TITLE
Remove code made redundant by use of define-derived-mode

### DIFF
--- a/xah-css-mode.el
+++ b/xah-css-mode.el
@@ -951,12 +951,6 @@ This is called by emacs abbrev system."
 URL `http://ergoemacs.org/emacs/xah-css-mode.html'
 
 \\{xah-css-key-map}"
-
-  (kill-all-local-variables)
-
-  (setq mode-name "ξCSS")
-  (setq major-mode 'xah-css-mode)
-
   (set-syntax-table xah-css-syntax-table)
   (setq font-lock-defaults '((xah-css-font-lock-keywords)))
 
@@ -967,9 +961,6 @@ URL `http://ergoemacs.org/emacs/xah-css-mode.html'
   (setq-local comment-start-skip "/\\*+[ \t]*")
   (setq-local comment-end "*/")
   (setq-local comment-end-skip "[ \t]*\\*+/")
-
-  (run-mode-hooks 'xah-css-mode-hook)
-
 )
 
 (add-to-list 'auto-mode-alist '("\\.css\\'" . xah-css-mode))


### PR DESCRIPTION
This standard major mode code is generated automatically by the `define-derived-mode` macro.

If you rename `xah-css-key-map` to the more idiomatic `xah-css-mode-map`, you can also remove the `use-local-map` call.

I *think* you might be able to remove `(set-syntax-table xah-css-syntax-table)` and `(setq local-abbrev-table xah-css-abbrev-table)` too -- try macroexpanding the `define-derived-mode` form to see if it already generates that code for you.